### PR TITLE
Implement breadcrumbs

### DIFF
--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -22,6 +22,7 @@ from ubuntudesign.documentation_builder.operations import (
     relativize_paths,
     replace_internal_links,
     replace_media_links,
+    set_active_navigation_items,
     write_html
 )
 from ubuntudesign.documentation_builder.builder import markdown_extensions
@@ -539,6 +540,57 @@ def test_replace_media_links():
         '\n\n<a href="/static/image.png">link</a>\n'
     )
     assert output_absolute == expected_output_absolute
+
+
+def test_set_active_navigation_items():
+    navigation_items = [
+        {
+            'title': 'parent one',
+            'location': '../child',
+
+            'children': [{'title': 'child one'}]
+        },
+        {
+            'title': 'parent two',
+
+            'children': [
+                {
+                    'title': 'child two',
+                    'location': 'childtwo.html',
+
+                    'children': [
+                        {'title': 'grandchild 1', 'location': 'grandchild1'},
+                        {'title': 'grandchild 2', 'location': 'grandchild2.md'}
+                    ]
+                }
+            ]
+        },
+        {'title': 'childfree parent'}
+    ]
+
+    expected_path = [
+        {'title': 'parent two'},
+        {'title': 'child two', 'location': 'childtwo.html'},
+        {'title': 'grandchild 2', 'location': 'grandchild2.md', 'active': True}
+    ]
+
+    active_path = set_active_navigation_items(
+        'grandchild2.html',
+        navigation_items
+    )
+
+    for index, expected_item in enumerate(expected_path):
+        active_item = active_path[index]
+        assert expected_item['title'] == active_item['title']
+        assert expected_item.get('location') == active_item.get('location')
+        assert expected_item.get('active') == active_item.get('active')
+
+    assert not navigation_items[0].get('active')
+    assert not navigation_items[1].get('active')
+    assert not navigation_items[2].get('active')
+    assert not navigation_items[1]['children'][0].get('active')
+    assert not navigation_items[1]['children'][0]['children'][0].get('active')
+    assert navigation_items[1]['children'][0]['children'][1].get('active')
 
 
 def test_write_html():

--- a/ubuntudesign/documentation_builder/builder.py
+++ b/ubuntudesign/documentation_builder/builder.py
@@ -25,6 +25,7 @@ from .operations import (
     replace_media_links,
     parse_markdown,
     prepare_branches,
+    set_active_navigation_items,
     write_html
 )
 
@@ -148,6 +149,15 @@ class Builder():
                     path.relpath(file_directory, branch_source)
                 )
                 metadata['site_root'] = site_root
+
+                navigation = metadata.get('navigation')
+
+                # Breadcrumbs
+                if navigation:
+                    metadata['breadcrumbs'] = set_active_navigation_items(
+                        path.basename(filepath),
+                        navigation
+                    )
 
                 html = parse_markdown(parser, template, filepath, metadata)
 

--- a/ubuntudesign/documentation_builder/operations.py
+++ b/ubuntudesign/documentation_builder/operations.py
@@ -304,7 +304,43 @@ def replace_media_links(
     return html
 
 
+def set_active_navigation_items(filename, items, parents=[]):
+    """
+    Given a list of navigation items and a filename,
+    recursively set the "active" navigation which links to that filename,
+    and return a list of nodes that lead to that file.
+    """
+
+    name = path.splitext(path.normpath(filename))[0]
+    active_items = []
+
+    for item in items:
+        location = item.get('location')
+
+        if location:
+            location_name = path.splitext(
+                path.normpath(location)
+            )[0]
+
+            if location_name == name:
+                item['active'] = True
+                active_items = parents + [item]
+                break
+
+        if not active_items and item.get('children'):
+            active_items = set_active_navigation_items(
+                filename,
+                item['children'],
+                parents + [item]
+            )
+            if active_items:
+                break
+
+    return active_items
+
+
 def write_html(html, output_filepath):
+
     """
     Write HTML content to an HTML file
     """

--- a/ubuntudesign/documentation_builder/resources/template.html
+++ b/ubuntudesign/documentation_builder/resources/template.html
@@ -98,6 +98,10 @@
         display: none;
       }
 
+      .p-breadcrumbs {
+        display: none;
+      }
+
       @media (max-width: 767px) {
         .p-navigation__logo {
           margin: 0 1rem;
@@ -123,6 +127,12 @@
 
         .p-sidebar-nav {
           display: none;
+        }
+
+        .p-breadcrumbs {
+          display: block;
+          margin-left: 1rem;
+          margin-top: 1rem;
         }
 
         .theme__sidebar-toggle:checked + .p-sidebar-nav {
@@ -160,7 +170,7 @@
               {% for item in navigation %}
               <li class="p-sidebar-nav__group">
                 {% if item.location %}
-                <a class="p-sidebar-nav__link" href="{{ item.location }}">{{ item.title }}</a>
+                <a class="p-sidebar-nav__link {% if item.active %}is-active{% endif %}" href="{{ item.location }}">{{ item.title }}</a>
                 {% else %}
                 <h4 class="p-sidebar-nav__header">{{ item.title }}</h4>
                 {% endif %}
@@ -171,7 +181,7 @@
                     {% for child in item.children %}
                     <li>
                       {% if child.location %}
-                      <a class="p-sidebar-nav__link" href="{{ child.location }}">
+                      <a class="p-sidebar-nav__link {% if child.active %}is-active{% endif %}" href="{{ child.location }}">
                         {{ child.title }}
                       </a>
                       {% else %}
@@ -184,7 +194,7 @@
                           {% for grandchild in child.children %}
                           <li>
                             {% if grandchild.location %}
-                            <a class="p-sidebar-nav__link" href="{{ grandchild.location }}">
+                            <a class="p-sidebar-nav__link {% if grandchild.active %}is-active{% endif %}" href="{{ grandchild.location }}">
                               {{ grandchild.title }}
                             </a>
                             {% else %}
@@ -258,14 +268,6 @@
             return Boolean(navElement.querySelector('ul'));
           }
 
-          /* Add active links */
-          var navLinks = document.querySelectorAll('.p-sidebar-nav a');
-          navLinks.forEach(function(link) {
-            if (link.href.replace(/index(.html)?/, '') == location.href.replace(/index(.html)?/, '')) {
-              link.classList.add('is-active');
-            }
-          });
-
           /**
            * Add "collaped" classes to all provided list items
            * unless they're "active".
@@ -305,6 +307,15 @@
           }
           </script>
         </div>
+        <nav class="p-breadcrumbs">
+          {% for breadcrumb in breadcrumbs %}
+            {% if breadcrumb.active or not breadcrumb.location %}
+              <span class="p-breadcrumbs__link">{{ breadcrumb.title }}</span>
+            {% else %}
+              <a class="p-breadcrumbs__link" href="{{ breadcrumb.location }}">{{ breadcrumb.title }}</a>
+            {% endif %}
+          {% endfor %}
+        </nav>
         {% endif %}
         <div class="col-12 theme__main">
           <main id="main-content" class="theme__inner">


### PR DESCRIPTION
Traverse the metadata tree to perform two tasks:

- identify and set the "active" item in the navigation tree (replacing the old JavaScript solution)
- build a list of "breadcrumb" items - the current active item and all of its parents

Then pass these items through to the template.

Tests are included - we should still have 100% test coverage.

QA

---

First run tests:

``` bash
./setup.py test
```

Look for `tests/test_operations.py::test_set_active_navigation_items PASSED`, and see that we still have 100% code coverage (100-freaking-percent baby!).

Now build some documentation:

``` bash
git clone -b 1.0.0-structure https://github.com/nottrobin/ubuntu-core-docs.git
pip3 install --user --upgrade .  # Install python modules
bin/documentation-builder --base-directory ubuntu-code-docs  # Build the docs
xdg-open build/en/index.html  # Check the built docs
```

Check that the breadcrumbs are visible on small screen only and look good.
